### PR TITLE
7.6 给format添加了const

### DIFF
--- a/src/7.6使用格式库格式化文本.cpp
+++ b/src/7.6使用格式库格式化文本.cpp
@@ -14,7 +14,7 @@ struct std::formatter<Frac<T>> {
 		return ctx.begin();
 	}
 	template<typename FormatContext>
-	constexpr auto format(const Frac<T>& f, FormatContext& ctx) {
+	constexpr auto format(const Frac<T>& f, FormatContext& ctx) const {
 		return std::format_to(ctx.out(), "{0:d}/{1:d}", f.n, f.d);
 	}
 };
@@ -39,7 +39,7 @@ struct std::formatter<Frac2<T>> {
 		m_fmt[m_buffer_len++] = '}';
 		return iter;
 	}
-	constexpr auto format(const Frac2<T>& f, auto& ctx) {
+	constexpr auto format(const Frac2<T>& f, auto& ctx) const {
 		std::string fmt{};
 		fmt += m_fmt, fmt += "/", fmt += m_fmt;
 		auto iter = std::vformat_to(ctx.out(), fmt, std::make_format_args(f.n,f.d));


### PR DESCRIPTION
【副群主】mq白 2024/1/8 23:36:50
早期

【副群主】mq白 2024/1/8 23:36:51
早期

【副群主】mq白 2024/1/8 23:36:55
gcc13没有发布的时候

【副群主】mq白 2024/1/8 23:36:57
msvc是允许的

【副群主】mq白 2024/1/8 23:37:03
然后标准其实也没明确规定

【副群主】mq白 2024/1/8 23:37:08
也不好说是msvc有问题

